### PR TITLE
Rename `crate_name` back to `package`

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -6,7 +6,7 @@ use toml;
 #[derive(Debug, PartialEq)]
 pub struct Advisory {
     pub id: String,
-    pub crate_name: String,
+    pub package: String,
     pub patched_versions: Vec<VersionReq>,
     pub date: Option<String>,
     pub url: Option<String>,
@@ -19,7 +19,7 @@ impl Advisory {
     pub fn from_toml_value(value: &toml::Value) -> Result<Advisory> {
         Ok(Advisory {
             id: String::from(try!(value["id"].as_str().ok_or(Error::MissingAttribute))),
-            crate_name: String::from(try!(value["crate_name"].as_str().ok_or(Error::MissingAttribute))),
+            package: String::from(try!(value["package"].as_str().ok_or(Error::MissingAttribute))),
             patched_versions: try!(parse_versions(&value["patched_versions"])),
             date: value["date"].as_str().map(String::from),
             url: value["url"].as_str().map(String::from),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl AdvisoryDatabase {
         for advisory_toml in advisories_toml.iter() {
             let advisory = try!(Advisory::from_toml_value(advisory_toml));
 
-            let mut crate_vec = match crates.entry(advisory.crate_name.clone()) {
+            let mut crate_vec = match crates.entry(advisory.package.clone()) {
                 Vacant(entry) => entry.insert(Vec::new()),
                 Occupied(entry) => entry.into_mut(),
             };
@@ -115,7 +115,7 @@ mod tests {
         let ref example_advisory = db.find("RUSTSEC-2017-0001").unwrap();
 
         assert_eq!(example_advisory.id, "RUSTSEC-2017-0001");
-        assert_eq!(example_advisory.crate_name, "sodiumoxide");
+        assert_eq!(example_advisory.package, "sodiumoxide");
         assert_eq!(example_advisory.patched_versions[0],
                    VersionReq::parse(">= 0.0.14").unwrap());
         assert_eq!(example_advisory.date, Some(String::from("2017-01-26")));


### PR DESCRIPTION
The name "package" is used by Cargo.lock, so we should follow suit