### PR TITLE
Add AdvisoryDatabase::find_vulns_for_crate()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     Response,
     Parse,
     MissingAttribute,
+    InvalidAttribute,
     MalformedVersion,
 }
 
@@ -23,6 +24,7 @@ impl StdError for Error {
             Error::Response => "invalid response",
             Error::Parse => "couldn't parse data",
             Error::MissingAttribute => "expected attribute missing",
+            Error::InvalidAttribute => "attribute is not the expected type/format",
             Error::MalformedVersion => "malformatted version requirement",
         }
     }


### PR DESCRIPTION
Find advisories containing unpatched vulnerabilities given a crate name and
version.

This functionality is intended for use by cargo-audit, but as it's generally
reusable it felt like it belongs here.

This additionally includes what's nearly a total rewrite of the advisory parser,
eliminating some extant panics. The parser could probably benefit from e.g.
serde, unfortunately that would make it difficult to have the parser output
structs containing semver::VersionReqs, which is very handy.

Perhaps it could be rewritten to use a two-pass parser, but for now the
handwritten one isn't *too* unwieldy.