### PR TITLE
Make "advisory" and "error" modules public

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -1,3 +1,5 @@
+//! Advisory type and related parsing code
+
 use error::{Error, Result};
 use semver::VersionReq;
 use toml;
@@ -5,17 +7,30 @@ use toml;
 /// An individual security advisory pertaining to a single vulnerability
 #[derive(Debug, PartialEq)]
 pub struct Advisory {
+    /// Security advisory ID (e.g. RUSTSEC-YYYY-NNNN)
     pub id: String,
+
+    /// Name of affected crate
     pub package: String,
+
+    /// Versions which are patched and not vulnerable (expressed as semantic version requirements)
     pub patched_versions: Vec<VersionReq>,
+
+    /// Date vulnerability was originally disclosed (optional)
     pub date: Option<String>,
+
+    /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
     pub url: Option<String>,
+
+    /// One-liner description of a vulnerability
     pub title: String,
+
+    /// Extended description of a vulnerability
     pub description: String,
 }
 
 impl Advisory {
-    /// Parse an Advisory from a TOML value object
+    /// Parse an Advisory from a TOML table object
     pub fn from_toml_table(value: &toml::value::Table) -> Result<Advisory> {
         Ok(Advisory {
             id: try!(parse_mandatory_string(value, "id")),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,27 @@
+//! Error types used by this crate
+
 use std::{fmt, result};
 use std::error::Error as StdError;
 
+/// Custom error type for this library
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum Error {
+    /// An error occurred while making a request to the advisory database
     Request,
+
+    /// Advisory database server responded with an error
     Response,
+
+    /// Couldn't parse response data
     Parse,
+
+    /// Response data is missing an expected attribute
     MissingAttribute,
+
+    /// Response data contains an attributed which is the wrong type or otherwise invalid
     InvalidAttribute,
+
+    /// Version requirement is not properly formed
     MalformedVersion,
 }
 
@@ -30,4 +44,5 @@ impl StdError for Error {
     }
 }
 
+/// Custom result type for this library
 pub type Result<T> = result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ extern crate reqwest;
 extern crate semver;
 extern crate toml;
 
-mod advisory;
-mod error;
+pub mod advisory;
+pub mod error;
 
 use advisory::Advisory;
 use error::{Error, Result};


### PR DESCRIPTION
They are part of the public API and should be public