### PR TITLE
Lockfile support

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -1,8 +1,9 @@
 //! Advisory type and related parsing code
 
-use error::{Error, Result};
+use error::Result;
 use semver::VersionReq;
 use toml;
+use util;
 
 /// An individual security advisory pertaining to a single vulnerability
 #[derive(Debug, PartialEq)]
@@ -33,42 +34,13 @@ impl Advisory {
     /// Parse an Advisory from a TOML table object
     pub fn from_toml_table(value: &toml::value::Table) -> Result<Advisory> {
         Ok(Advisory {
-            id: try!(parse_mandatory_string(value, "id")),
-            package: try!(parse_mandatory_string(value, "package")),
-            patched_versions: try!(parse_versions(&value["patched_versions"])),
-            date: try!(parse_optional_string(value, "date")),
-            url: try!(parse_optional_string(value, "url")),
-            title: try!(parse_mandatory_string(value, "title")),
-            description: try!(parse_mandatory_string(value, "description")),
+            id: util::parse_mandatory_string(value, "id")?,
+            package: util::parse_mandatory_string(value, "package")?,
+            patched_versions: util::parse_versions(value, "patched_versions")?,
+            date: util::parse_optional_string(value, "date")?,
+            url: util::parse_optional_string(value, "url")?,
+            title: util::parse_mandatory_string(value, "title")?,
+            description: util::parse_mandatory_string(value, "description")?,
         })
-    }
-}
-
-fn parse_optional_string(table: &toml::value::Table, attribute: &str) -> Result<Option<String>> {
-    match table.get(attribute) {
-        Some(v) => Ok(Some(String::from(try!(v.as_str().ok_or(Error::InvalidAttribute))))),
-        None => Ok(None),
-    }
-}
-
-fn parse_mandatory_string(table: &toml::value::Table, attribute: &str) -> Result<String> {
-    let str = try!(parse_optional_string(table, attribute));
-    str.ok_or(Error::MissingAttribute)
-}
-
-fn parse_versions(value: &toml::Value) -> Result<Vec<VersionReq>> {
-    match *value {
-        toml::Value::Array(ref arr) => {
-            let mut result = Vec::new();
-            for version in arr {
-                let version_str = try!(version.as_str().ok_or(Error::MissingAttribute));
-                let version_req = try!(VersionReq::parse(version_str)
-                    .map_err(|_| Error::MalformedVersion));
-
-                result.push(version_req)
-            }
-            Ok(result)
-        }
-        _ => Err(Error::MissingAttribute),
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,11 +6,11 @@ use std::error::Error as StdError;
 /// Custom error type for this library
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum Error {
-    /// An error occurred while making a request to the advisory database
-    Request,
+    /// An error occurred performing an I/O operation (e.g. network, file)
+    IO,
 
     /// Advisory database server responded with an error
-    Response,
+    ServerResponse,
 
     /// Couldn't parse response data
     Parse,
@@ -34,8 +34,8 @@ impl fmt::Display for Error {
 impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::Request => "network request failed",
-            Error::Response => "invalid response",
+            Error::IO => "I/O operation failed",
+            Error::ServerResponse => "invalid response",
             Error::Parse => "couldn't parse data",
             Error::MissingAttribute => "expected attribute missing",
             Error::InvalidAttribute => "attribute is not the expected type/format",

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,0 +1,87 @@
+//! Types for representing Cargo.lock files
+
+use AdvisoryDatabase;
+use advisory::Advisory;
+use error::{Error, Result};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use toml;
+use util;
+
+/// Entry from Cargo.lock's `[[package]]` array
+/// TODO: serde macros or switch to cargo's builtin types
+#[derive(Debug, PartialEq)]
+pub struct Package {
+    /// Name of a dependent crate
+    pub name: String,
+
+    /// Version of dependent crate
+    pub version: String,
+}
+
+/// Parsed Cargo.lock file containing dependencies
+#[derive(Debug, PartialEq)]
+pub struct Lockfile {
+    /// Dependencies enumerated in the lockfile
+    pub packages: Vec<Package>,
+}
+
+impl Lockfile {
+    /// Load lockfile from disk
+    pub fn load(filename: &str) -> Result<Self> {
+        let path = Path::new(filename);
+        let mut file = File::open(&path).or(Err(Error::IO))?;
+        let mut toml = String::new();
+
+        file.read_to_string(&mut toml).or(Err(Error::IO))?;
+        Self::from_toml(&toml)
+    }
+
+    /// Load lockfile from a TOML string
+    pub fn from_toml(string: &str) -> Result<Self> {
+        let toml = string.parse::<toml::Value>().or(Err(Error::Parse))?;
+
+        let packages_toml = match toml.get("package") {
+            Some(&toml::Value::Array(ref arr)) => arr,
+            _ => return Ok(Lockfile { packages: Vec::new() }),
+        };
+
+        let mut packages = Vec::new();
+
+        for package in packages_toml {
+            match *package {
+                toml::Value::Table(ref table) => {
+                    packages.push(Package {
+                        name: util::parse_mandatory_string(table, "name")?,
+                        version: util::parse_mandatory_string(table, "version")?,
+                    })
+                }
+                _ => return Err(Error::InvalidAttribute),
+            }
+        }
+
+        Ok(Lockfile { packages: packages })
+    }
+
+    /// Find all relevant vulnerabilities for this lockfile using the given database
+    pub fn vulnerabilities<'a>(&self, db: &'a AdvisoryDatabase) -> Result<Vec<&'a Advisory>> {
+        let mut result = Vec::new();
+
+        for package in &self.packages {
+            result.extend(&db.find_vulns_for_crate(&package.name, &package.version)?)
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lockfile::Lockfile;
+
+    #[test]
+    fn load_cargo_lockfile() {
+        Lockfile::load("Cargo.lock").unwrap();
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,35 @@
+use error::{Error, Result};
+use semver::VersionReq;
+use toml::value::Table;
+use toml::Value;
+
+pub fn parse_optional_string(table: &Table, attribute: &str) -> Result<Option<String>> {
+    match table.get(attribute) {
+        Some(v) => Ok(Some(String::from(v.as_str().ok_or(Error::InvalidAttribute)?))),
+        None => Ok(None),
+    }
+}
+
+pub fn parse_mandatory_string(table: &Table, attribute: &str) -> Result<String> {
+    let str = parse_optional_string(table, attribute)?;
+    str.ok_or(Error::MissingAttribute)
+}
+
+pub fn parse_versions(table: &Table, attribute: &str) -> Result<Vec<VersionReq>> {
+    match table.get(attribute) {
+        Some(&Value::Array(ref arr)) => {
+            let mut result = Vec::new();
+
+            for version in arr {
+                let version_str = version.as_str().ok_or(Error::MissingAttribute)?;
+                let version_req = VersionReq::parse(version_str).or(Err(Error::MalformedVersion))?;
+
+                result.push(version_req)
+            }
+
+            Ok(result)
+        }
+        Some(_) => Err(Error::InvalidAttribute),
+        None => Err(Error::MissingAttribute),
+    }
+}


### PR DESCRIPTION
Adds a `lockfile::Lockfile` type for modeling `Cargo.lock` files

This could potentially be replaced with built-in types from Cargo, but suffices
to meet RustSec's needs for now.