### PR TITLE
Add last maintained field to AdvisoryDatabase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["api-bindings", "development-tools"]
 keywords = ["rustsec", "security", "advisory", "vulnerability"]
 
 [dependencies]
+chrono = "^0.4"
 reqwest = "^0.4"
 semver = "^0"
 toml = "^0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod lockfile;
 mod util;
 
+extern crate chrono;
 extern crate reqwest;
 extern crate semver;
 extern crate toml;


### PR DESCRIPTION
Initial work for RustSec/advisory-db#27.

I'm parsing a `[meta]` section from `Advisories.toml` and grabbing a field `last_maintained`.

The purpose of this field is to let `cargo audit` report if the database goes too long without being updated.

Every time a human goes though and checks for new advisories, they'd update this field with the current date and time. The idea being that even if no new advisories are found, developers can be reasonably confidant that someone is still paying attention.