### PR TITLE
Switch to git2-based fetcher for advisory-db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,14 @@ categories = ["api-bindings", "development-tools"]
 keywords = ["rustsec", "security", "advisory", "vulnerability"]
 
 [dependencies]
+chrono = { version = "0.4", optional = true }
 failure = "0.1"
 failure_derive = "0.1"
-reqwest = "0.8"
+git2 = "0.7"
 semver = { version = "0.9", features = ["serde"] }
 serde = "1"
 serde_derive = "1"
 toml = "0.4"
+
+[features]
+default = ["chrono"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types used by this crate
 
 use failure::{Backtrace, Context, Fail};
-use reqwest;
+use git2;
 use std::fmt::{self, Display};
 use std::io;
 use std::str::Utf8Error;
@@ -51,29 +51,21 @@ impl Display for Error {
 /// Custom error type for this library
 #[derive(Copy, Clone, Debug, Eq, Fail, PartialEq)]
 pub enum ErrorKind {
+    /// Invalid argument or parameter
+    #[fail(display = "bad parameter")]
+    BadParam,
+
     /// An error occurred performing an I/O operation (e.g. network, file)
     #[fail(display = "I/O operation failed")]
     Io,
-
-    /// Advisory database server responded with an error
-    #[fail(display = "invalid response")]
-    ServerResponse,
 
     /// Couldn't parse response data
     #[fail(display = "couldn't parse data")]
     Parse,
 
-    /// Response data is missing an expected attribute
-    #[fail(display = "expected attribute missing")]
-    MissingAttribute,
-
-    /// Response data contains an attributed which is the wrong type or otherwise invalid
-    #[fail(display = "attribute is not the expected type/format")]
-    InvalidAttribute,
-
-    /// Version requirement is not properly formed
-    #[fail(display = "malformatted version requirement")]
-    MalformedVersion,
+    /// Git operation failed
+    #[fail(display = "git operation failed")]
+    Repo,
 }
 
 /// Create a new error (of a given enum variant) with a formatted message
@@ -99,21 +91,27 @@ macro_rules! fail {
     };
 }
 
-impl From<io::Error> for Error {
-    fn from(other: io::Error) -> Self {
-        err!(ErrorKind::Io, &other)
-    }
-}
-
-impl From<reqwest::Error> for Error {
-    fn from(other: reqwest::Error) -> Self {
-        err!(ErrorKind::Io, &other)
-    }
-}
-
 impl From<Utf8Error> for Error {
     fn from(other: Utf8Error) -> Self {
         err!(ErrorKind::Parse, &other)
+    }
+}
+
+impl From<fmt::Error> for Error {
+    fn from(other: fmt::Error) -> Self {
+        err!(ErrorKind::Io, &other)
+    }
+}
+
+impl From<git2::Error> for Error {
+    fn from(other: git2::Error) -> Self {
+        err!(ErrorKind::Repo, &other)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(other: io::Error) -> Self {
+        err!(ErrorKind::Io, &other)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,12 @@
 #![forbid(unsafe_code)]
 #![doc(html_root_url = "https://docs.rs/rustsec/0.6.0")]
 
+#[cfg(feature = "chrono")]
+extern crate chrono;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
-extern crate reqwest;
+extern crate git2;
 extern crate semver;
 extern crate serde;
 #[macro_use]
@@ -28,6 +30,7 @@ pub mod advisory;
 pub mod db;
 pub mod lockfile;
 pub mod package;
+pub mod repository;
 pub mod vulnerability;
 
 pub use advisory::*;
@@ -36,7 +39,3 @@ pub use error::*;
 pub use lockfile::*;
 pub use package::*;
 pub use vulnerability::*;
-
-/// URL where the TOML file containing the advisory database is located
-pub const ADVISORY_DB_URL: &str =
-    "https://raw.githubusercontent.com/RustSec/advisory-db/master/Advisories.toml";

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -32,7 +32,7 @@ impl Lockfile {
 
     /// Find all relevant vulnerabilities for this lockfile using the given database
     pub fn vulnerabilities(&self, db: &AdvisoryDatabase) -> Vec<Vulnerability> {
-        db.vulns_for_lockfile(self)
+        Vulnerability::find_all(db, self)
     }
 }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,0 +1,239 @@
+//! Git repository handling for the RustSec advisory DB
+
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use git2::{ObjectType, Repository as GitRepository, RepositoryState};
+use std::{
+    env,
+    fmt::Write,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+use error::{Error, ErrorKind};
+
+/// Location of the RustSec advisory database for crates.io
+pub const ADVISORY_DB_REPO_URL: &str = "https://github.com/RustSec/advisory-db.git";
+
+/// Number of days after which the repo will be considered stale
+pub const DAYS_UNTIL_STALE: usize = 90;
+
+/// Directory under ~/.cargo where the advisory-db repo will be kept
+const ADVISORY_DB_DIRECTORY: &str = "advisory-db";
+
+/// Ref for master in the local repository
+#[cfg(feature = "chrono")]
+const LOCAL_MASTER_REF: &str = "refs/heads/master";
+
+/// Ref for master in the remote repository
+#[cfg(feature = "chrono")]
+const REMOTE_MASTER_REF: &str = "refs/remotes/origin/master";
+
+/// Git repository for a Rust advisory DB
+pub struct Repository {
+    /// Path to the Git repository
+    path: PathBuf,
+
+    /// Repository object
+    repo: GitRepository,
+}
+
+impl Repository {
+    /// Location of the default `advisory-db` repository for crates.io
+    pub fn default_path() -> PathBuf {
+        if let Some(path) = env::var_os("CARGO_HOME") {
+            PathBuf::from(path).join(ADVISORY_DB_DIRECTORY)
+        } else {
+            panic!("Can't locate CARGO_HOME!");
+        }
+    }
+
+    /// Fetch the default repository
+    #[cfg(feature = "chrono")]
+    pub fn fetch_default_repo() -> Result<Self, Error> {
+        Self::fetch(ADVISORY_DB_REPO_URL, Repository::default_path())
+    }
+
+    /// Create a new `Repository` with the given URL and path
+    #[cfg(feature = "chrono")]
+    pub fn fetch<P: Into<PathBuf>>(url: &str, into_path: P) -> Result<Self, Error> {
+        if !url.starts_with("https://") {
+            fail!(
+                ErrorKind::BadParam,
+                "expected {} to start with https://",
+                url
+            );
+        }
+
+        let path = into_path.into();
+
+        if let Some(parent) = path.parent() {
+            if !parent.is_dir() {
+                fail!(ErrorKind::BadParam, "not a directory: {}", parent.display());
+            }
+        } else {
+            fail!(ErrorKind::BadParam, "invalid directory: {}", path.display())
+        }
+
+        if path.exists() {
+            let repo = GitRepository::open(&path)?;
+            let refspec = LOCAL_MASTER_REF.to_owned() + ":" + REMOTE_MASTER_REF;
+            repo.remote_anonymous(url)?
+                .fetch(&[refspec.as_str()], None, None)?;
+        } else {
+            GitRepository::clone(url, &path)?;
+        }
+
+        let repo = Self::open(path)?;
+
+        // Ensure HEAD is on master
+        repo.repo.set_head(LOCAL_MASTER_REF)?;
+
+        // Ensure repo is fresh
+        repo.latest_commit()?.ensure_fresh()?;
+
+        Ok(repo)
+    }
+
+    /// Open a repository at the given path
+    pub fn open<P: Into<PathBuf>>(into_path: P) -> Result<Self, Error> {
+        let path = into_path.into();
+        let repo = GitRepository::open(&path)?;
+
+        // Ensure the repo is in a clean state
+        match repo.state() {
+            RepositoryState::Clean => Ok(Repository { path, repo }),
+            state => fail!(ErrorKind::Repo, "bad repository state: {:?}", state),
+        }
+    }
+
+    /// Get information about the latest commit to the repo
+    pub fn latest_commit(&self) -> Result<CommitInfo, Error> {
+        CommitInfo::from_repo_head(self)
+    }
+
+    /// Read a file from the repository to a `String`
+    pub fn read_file<P: AsRef<Path>>(&self, path: P) -> Result<RepoFile, Error> {
+        let mut file = File::open(self.path.join(path.as_ref()))?;
+        RepoFile::new(path.as_ref(), &mut file)
+    }
+}
+
+/// Information about a commit to the Git repository
+#[derive(Debug)]
+pub struct CommitInfo {
+    /// ID (i.e. SHA-1 hash) of the latest commit
+    pub commit_id: String,
+
+    /// Name of the current ref
+    pub ref_name: String,
+
+    /// Summary message for the commit
+    pub summary: String,
+
+    /// Commit time in number of seconds since the UNIX epoch
+    #[cfg(feature = "chrono")]
+    pub time: DateTime<Utc>,
+}
+
+impl CommitInfo {
+    /// Get information about HEAD
+    pub fn from_repo_head(repo: &Repository) -> Result<Self, Error> {
+        let head = repo.repo.head()?;
+
+        let ref_name = head
+            .name()
+            .ok_or_else(|| {
+                err!(
+                    ErrorKind::Repo,
+                    "no current ref name for: {}",
+                    repo.path.display()
+                )
+            })?
+            .to_owned();
+
+        let target = head.target().ok_or_else(|| {
+            err!(
+                ErrorKind::Repo,
+                "no ref target for: {}",
+                repo.path.display()
+            )
+        })?;
+
+        let mut commit_id = String::new();
+
+        for byte in target.as_bytes().iter() {
+            write!(commit_id, "{:02x}", byte)?;
+        }
+
+        let commit_object = repo.repo.find_object(target, Some(ObjectType::Commit))?;
+        let commit = commit_object.as_commit().unwrap();
+
+        let summary = commit
+            .summary()
+            .ok_or_else(|| err!(ErrorKind::Repo, "no commit summary for {}", commit_id))?
+            .to_owned();
+
+        #[cfg(feature = "chrono")]
+        let time = DateTime::from_utc(
+            NaiveDateTime::from_timestamp(commit.time().seconds(), 0),
+            Utc,
+        );
+
+        Ok(CommitInfo {
+            commit_id,
+            ref_name,
+            summary,
+            #[cfg(feature = "chrono")]
+            time,
+        })
+    }
+
+    /// Determine if the repository is fresh or stale (i.e. has it recently been committed to)
+    #[cfg(feature = "chrono")]
+    pub fn ensure_fresh(&self) -> Result<(), Error> {
+        let fresh_after_date = Utc::now()
+            .checked_sub_signed(Duration::days(DAYS_UNTIL_STALE as i64))
+            .unwrap();
+
+        if self.time > fresh_after_date {
+            Ok(())
+        } else {
+            fail!(
+                ErrorKind::Repo,
+                "stale repo: not updated for {} days (last commit: {:?})",
+                DAYS_UNTIL_STALE,
+                self.time
+            )
+        }
+    }
+}
+
+/// File stored in the repository
+#[derive(Debug)]
+pub struct RepoFile {
+    /// Relative location of file in repository
+    path: PathBuf,
+
+    /// Contents of file as a string
+    body: String,
+}
+
+impl RepoFile {
+    /// Create a RepoFile from a relative repo `Path` and a `File`
+    pub(crate) fn new<P: Into<PathBuf>>(into_pathbuf: P, file: &mut File) -> Result<Self, Error> {
+        let mut body = String::new();
+        file.read_to_string(&mut body)?;
+        Ok(Self {
+            path: into_pathbuf.into(),
+            body,
+        })
+    }
+}
+
+impl AsRef<str> for RepoFile {
+    fn as_ref(&self) -> &str {
+        self.body.as_ref()
+    }
+}

--- a/src/vulnerability.rs
+++ b/src/vulnerability.rs
@@ -1,6 +1,8 @@
 //! An `Advisory` for which a particular crate in a `Lockfile` is vulnerable
 
 use advisory::Advisory;
+use db::AdvisoryDatabase;
+use lockfile::Lockfile;
 use package::Package;
 
 /// A vulnerable package and the associated advisory
@@ -14,6 +16,19 @@ pub struct Vulnerability {
 }
 
 impl Vulnerability {
+    /// Find all vulnerabilities for a given `AdvisoryDatabase` and `Lockfile`
+    pub fn find_all(db: &AdvisoryDatabase, lockfile: &Lockfile) -> Vec<Vulnerability> {
+        let mut vulns = vec![];
+
+        for package in &lockfile.packages {
+            for advisory in db.advisories_for_crate(package.name.clone(), &package.version) {
+                vulns.push(Self::new(advisory, &package))
+            }
+        }
+
+        vulns
+    }
+
     /// Create a new vulnerability object from the given references
     pub fn new(advisory: &Advisory, package: &Package) -> Self {
         Self {


### PR DESCRIPTION
Switches from reqwest to using the git2 crate, ala cargo.

With this we can (eventually) get rid of Advisories.toml as all of the individual TOML files for each of the advisories will be easily available locally.

It also adds a freshness check to ensure the advisory-db repo has been updated in the past 90 days, erroring out if it is stale, in hopes of detecting situations where it is not being properly updated.

This change removes a whopping 85 crates while adding only 10, while bringing the whole project a bit more inline with upstream Cargo.