### PR TITLE
Parse individual advisory .toml files rather than Advisories.toml

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -1,6 +1,7 @@
 //! Security advisories in the RustSec database
 
 use semver::VersionReq;
+use std::fmt;
 
 use package::PackageName;
 
@@ -39,6 +40,12 @@ impl AsRef<str> for AdvisoryId {
     }
 }
 
+impl fmt::Display for AdvisoryId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl<'a> From<&'a str> for AdvisoryId {
     fn from(string: &'a str) -> AdvisoryId {
         AdvisoryId(string.into())
@@ -49,6 +56,12 @@ impl Into<String> for AdvisoryId {
     fn into(self) -> String {
         self.0
     }
+}
+
+/// Wrapper struct around advisories since they're each in a table
+#[derive(Serialize, Deserialize)]
+pub(crate) struct AdvisoryWrapper {
+    pub(crate) advisory: Advisory,
 }
 
 /// Dates on advisories

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,6 +1,7 @@
 //! Crate metadata as parsed from `Cargo.lock`
 
 use semver::Version;
+use std::fmt;
 
 /// A Rust package (i.e. crate) as structured in `Cargo.lock`
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -25,6 +26,12 @@ pub struct PackageName(pub String);
 impl AsRef<str> for PackageName {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+impl fmt::Display for PackageName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 


### PR DESCRIPTION
This change traverses the `crates/` directory of the advisory-db, parsing advisories out of individual TOML files rather than the monolithic Advisories.toml file.

It also fixes the repository updater code (eek, no tests!) to update the local master ref to match the remote after doing a fetch, and doing a reset of the state of the repository to ensure the local copy is up-to-date.