### PR TITLE
Parse aliases, references, and unaffected versions

### DIFF
--- a/src/advisory.rs
+++ b/src/advisory.rs
@@ -17,8 +17,20 @@ pub struct Advisory {
     /// Versions which are patched and not vulnerable (expressed as semantic version requirements)
     pub patched_versions: Vec<VersionReq>,
 
-    /// Date vulnerability was originally disclosed (optional)
-    pub date: Option<Date>,
+    /// Versions which were never affected in the first place
+    #[serde(default)]
+    pub unaffected_versions: Vec<VersionReq>,
+
+    /// Advisory IDs in other databases which point to the same advisory
+    #[serde(default)]
+    pub aliases: Vec<AdvisoryId>,
+
+    /// Advisory IDs which are related to this advisory
+    #[serde(default)]
+    pub references: Vec<AdvisoryId>,
+
+    /// Date this advisory was officially issued
+    pub date: Date,
 
     /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
     pub url: Option<String>,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,7 +17,7 @@ fn test_integration() {
         example_advisory.patched_versions[0],
         VersionReq::parse(">= 0.0.14").unwrap()
     );
-    assert_eq!(example_advisory.date, Some(Date::from("2017-01-26")));
+    assert_eq!(example_advisory.date, Date::from("2017-01-26"));
     assert_eq!(
         example_advisory.url,
         Some(String::from(


### PR DESCRIPTION
This data has been in advisories, but inaccessible to the client