### PR TITLE
advisory/keyword.rs: Cargo-like keyword support

### DIFF
--- a/src/advisory/keyword.rs
+++ b/src/advisory/keyword.rs
@@ -1,0 +1,27 @@
+use serde::{de::Error as DeError, Deserialize, Deserializer};
+
+use error::Error;
+
+/// Keywords on advisories, similar to Cargo keywords
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize)]
+pub struct Keyword(String);
+
+impl Keyword {
+    /// Create a new keyword
+    // TODO: validate keywords according to Cargo-like rules
+    pub fn new<S: Into<String>>(keyword: S) -> Result<Self, Error> {
+        Ok(Keyword(keyword.into()))
+    }
+
+    /// Borrow this keyword as a string slice
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl<'de> Deserialize<'de> for Keyword {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Self::new(String::deserialize(deserializer)?)
+            .map_err(|e| D::Error::custom(format!("{}", e)))
+    }
+}

--- a/src/advisory/mod.rs
+++ b/src/advisory/mod.rs
@@ -7,10 +7,12 @@ use package::PackageName;
 mod date;
 mod id;
 mod iter;
+mod keyword;
 
 pub use self::date::*;
 pub use self::id::*;
 pub use self::iter::Iter;
+pub use self::keyword::Keyword;
 
 /// An individual security advisory pertaining to a single vulnerability
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -38,6 +40,10 @@ pub struct Advisory {
     /// Advisory IDs which are related to this advisory
     #[serde(default)]
     pub references: Vec<AdvisoryId>,
+
+    /// Freeform keywords which succinctly describe this vulnerability (e.g. "ssl", "rce", "xss")
+    #[serde(default)]
+    pub keywords: Vec<Keyword>,
 
     /// URL with an announcement (e.g. blog post, PR, disclosure issue, CVE)
     pub url: Option<String>,


### PR DESCRIPTION
Freeform keywords can be used to categorize vulnerabilities